### PR TITLE
Added rattr_initialize and longer method aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ Also provides conveniences for creating value objects, method objects, query met
 * [`attr_initialize`](#attr_initialize)
 * [`attr_private`](#attr_private)
 * [`attr_value`](#attr_value)
-* [`pattr_initialize`](#pattr_initialize)
-* [`vattr_initialize`](#vattr_initialize)
+* [`pattr_initialize`](#pattr_initialize) / [`attr_private_initialize`](#attr_private_initialize)
+* [`vattr_initialize`](#vattr_initialize) / [`attr_value_initialize`](#attr_value_initialize)
+* [`rattr_initialize`](#rattr_initialize) / [`attr_reader_initialize`](#attr_reader_initialize)
 * [`static_facade`](#static_facade)
 * [`method_object`](#method_object)
 * [`attr_implement`](#attr_implement)
@@ -71,13 +72,16 @@ It does not define writers, because [value objects](http://en.wikipedia.org/wiki
 
 
 ### `pattr_initialize`
+### `attr_private_initialize`
 
-`pattr_initialize :foo, :bar` defines both initializer and private readers: shortcut for
+`pattr_initialize :foo, :bar` defines both initializer and private readers. Shortcut for:
 
 ``` ruby
 attr_initialize :foo, :bar
 attr_private :foo, :bar
 ```
+
+`attr_private_initialize` is an alias for `pattr_initialize`.
 
 Example:
 
@@ -95,15 +99,17 @@ Item.new("Pug", 100).price_with_vat  # => 125.0
 
 [The `attr_initialize` notation](#attr_initialize) for hash arguments is also supported: `pattr_initialize :foo, [:bar, :baz!]`
 
-
 ### `vattr_initialize`
+### `attr_value_initialize`
 
-`vattr_initialize :foo, :bar` defines initializer, public readers and [value object identity](#attr_value): shortcut for
+`vattr_initialize :foo, :bar` defines initializer, public readers and [value object identity](#attr_value). Shortcut for:
 
 ``` ruby
 attr_initialize :foo, :bar
 attr_value :foo, :bar
 ```
+
+`attr_value_initialize` is an alias for `vattr_initialize`.
 
 Example:
 
@@ -118,6 +124,35 @@ Country.new("SE").code  # => "SE"
 
 [The `attr_initialize` notation](#attr_initialize) for hash arguments is also supported: `vattr_initialize :foo, [:bar, :baz!]`
 
+
+### `rattr_initialize`
+### `attr_reader_initialize`
+
+`rattr_initialize :foo, :bar` defines both initializer and public readers. Shortcut for:
+
+``` ruby
+attr_initialize :foo, :bar
+attr_reader :foo, :bar
+```
+
+`attr_reader_initialize` is an alias for `rattr_initialize`.
+
+Example:
+
+``` ruby
+class PublishBook
+  rattr_initalize :book_name, :publisher_backend
+
+  def call
+    publisher_backend.publish book_name
+  end
+end
+
+service = PublishBook.new("A Novel")
+service.book_name # => "A Novel"
+```
+
+[The `attr_initialize` notation](#attr_initialize) for hash arguments is also supported: `rattr_initialize :foo, [:bar, :baz!]`
 
 ### `static_facade`
 

--- a/lib/attr_extras.rb
+++ b/lib/attr_extras.rb
@@ -41,10 +41,21 @@ module AttrExtras
       attr_private(*Utils.flat_names(names))
     end
 
+    alias_method :attr_private_initialize, :pattr_initialize
+
     def vattr_initialize(*names, &block)
       attr_initialize(*names, &block)
       attr_value(*Utils.flat_names(names))
     end
+
+    alias_method :attr_value_initialize, :vattr_initialize
+
+    def rattr_initialize(*names, &block)
+      attr_initialize(*names, &block)
+      attr_reader(*Utils.flat_names(names))
+    end
+
+    alias_method :attr_reader_initialize, :rattr_initialize
 
     def static_facade(method_name, *names)
       define_singleton_method(method_name) do |*values|

--- a/spec/attr_implement_spec.rb
+++ b/spec/attr_implement_spec.rb
@@ -11,7 +11,7 @@ describe Object, ".attr_implement" do
     exception.message.must_equal "Implement a 'foo()' method"
   end
 
-  it "allows specifying arity and argument names" do
+  it "accepts specifying arity and argument names" do
     klass = Class.new do
       attr_implement :foo, [:name, :age]
     end

--- a/spec/attr_implement_spec.rb
+++ b/spec/attr_implement_spec.rb
@@ -11,7 +11,7 @@ describe Object, ".attr_implement" do
     exception.message.must_equal "Implement a 'foo()' method"
   end
 
-  it "accepts specifying arity and argument names" do
+  it "allows specifying arity and argument names" do
     klass = Class.new do
       attr_implement :foo, [:name, :age]
     end

--- a/spec/pattr_initialize_spec.rb
+++ b/spec/pattr_initialize_spec.rb
@@ -32,4 +32,13 @@ describe Object, ".pattr_initialize" do
 
     example.copy.must_equal "expected"
   end
+
+  it "accepts the alias attr_private_initializer" do
+    klass = Class.new do
+      attr_private_initialize :foo, :bar
+    end
+
+    example = klass.new("Foo", "Bar")
+    example.send(:foo).must_equal "Foo"
+  end
 end

--- a/spec/rattr_initialize_spec.rb
+++ b/spec/rattr_initialize_spec.rb
@@ -1,0 +1,30 @@
+require_relative "spec_helper"
+
+describe Object, ".rattr_initialize" do
+  it "creates both initializer and public readers" do
+    klass = Class.new do
+      rattr_initialize :foo, :bar
+    end
+
+    example = klass.new("Foo", "Bar")
+    example.public_send(:foo).must_equal "Foo"
+  end
+
+  it "works with hash ivars" do
+    klass = Class.new do
+      rattr_initialize :foo, [:bar, :baz!]
+    end
+
+    example = klass.new("Foo", :bar => "Bar", :baz => "Baz")
+    example.public_send(:baz).must_equal "Baz"
+  end
+
+  it "accepts the alias attr_reader_initializer" do
+    klass = Class.new do
+      attr_reader_initialize :foo, :bar
+    end
+
+    example = klass.new("Foo", "Bar")
+    example.public_send(:foo).must_equal "Foo"
+  end
+end

--- a/spec/vattr_initialize_spec.rb
+++ b/spec/vattr_initialize_spec.rb
@@ -36,4 +36,16 @@ describe Object, ".vattr_initialize" do
 
     called.must_equal true
   end
+
+  it "accepts the alias attr_value_initializer" do
+    klass = Class.new do
+      attr_value_initialize :foo, :bar
+    end
+
+    example1 = klass.new("Foo", "Bar")
+    example2 = klass.new("Foo", "Bar")
+
+    example1.foo.must_equal "Foo"
+    example1.must_equal example2
+  end
 end


### PR DESCRIPTION
This PR implements `rattr_implement` and longer method aliases (`attr_private_implement`, `attr_value_implement` and `attr_reader_implement`) discussed in #9 