### PR TITLE
Raise NotImplementedError in attr_implement

### DIFF
--- a/lib/attr_extras.rb
+++ b/lib/attr_extras.rb
@@ -77,7 +77,7 @@ module AttrExtras
               raise ArgumentError, "wrong number of arguments (#{provided_arity} for #{arity})"
             end
 
-            raise NotImplementedError, "Implement a '#{name}(#{arg_names.join(", ")})' method"
+            raise MethodNotImplementedError, "Implement a '#{name}(#{arg_names.join(", ")})' method"
           else
             super(name, *args)
           end
@@ -86,6 +86,11 @@ module AttrExtras
 
       include mod
     end
+  end
+
+  # MethodNotImplementedError inherits from Exception instead of StandardError so
+  # it will not be rescued unless it is specified explicitly (or its ancestor Exception).
+  class MethodNotImplementedError < Exception
   end
 end
 

--- a/lib/attr_extras.rb
+++ b/lib/attr_extras.rb
@@ -77,7 +77,7 @@ module AttrExtras
               raise ArgumentError, "wrong number of arguments (#{provided_arity} for #{arity})"
             end
 
-            raise "Implement a '#{name}(#{arg_names.join(", ")})' method"
+            raise NotImplementedError, "Implement a '#{name}(#{arg_names.join(", ")})' method"
           else
             super(name, *args)
           end

--- a/lib/attr_extras.rb
+++ b/lib/attr_extras.rb
@@ -88,8 +88,9 @@ module AttrExtras
     end
   end
 
-  # MethodNotImplementedError inherits from Exception instead of StandardError so
-  # it will not be rescued unless it is specified explicitly (or its ancestor Exception).
+  # To prevents masking coding errors, MethodNotImplementedError inherits
+  # from Exception instead of StandardError so it will not be rescued
+  # unless it is specified explicitly (or its ancestor Exception).
   class MethodNotImplementedError < Exception
   end
 end

--- a/spec/attr_implement_spec.rb
+++ b/spec/attr_implement_spec.rb
@@ -7,7 +7,7 @@ describe Object, ".attr_implement" do
     end
 
     example = klass.new
-    exception = lambda { example.foo }.must_raise RuntimeError
+    exception = lambda { example.foo }.must_raise NotImplementedError
     exception.message.must_equal "Implement a 'foo()' method"
   end
 
@@ -18,7 +18,7 @@ describe Object, ".attr_implement" do
 
     example = klass.new
 
-    exception = lambda { example.foo(1, 2) }.must_raise RuntimeError
+    exception = lambda { example.foo(1, 2) }.must_raise NotImplementedError
     exception.message.must_equal "Implement a 'foo(name, age)' method"
 
     lambda { example.foo }.must_raise ArgumentError
@@ -64,5 +64,21 @@ describe Object, ".attr_implement" do
     end
 
     lambda { klass.new.some_other_method }.must_raise NoMethodError
+  end
+
+  it "raises an exception that is not caught by a generic runtime error rescue" do
+    klass = Class.new do
+      attr_implement :foo
+    end
+
+    example = klass.new
+    exception = lambda {
+      begin
+        example.foo
+      rescue
+        "Runtime error occured"
+      end
+    }.must_raise NotImplementedError
+    exception.message.must_equal "Implement a 'foo()' method"
   end
 end

--- a/spec/attr_implement_spec.rb
+++ b/spec/attr_implement_spec.rb
@@ -7,7 +7,7 @@ describe Object, ".attr_implement" do
     end
 
     example = klass.new
-    exception = lambda { example.foo }.must_raise NotImplementedError
+    exception = lambda { example.foo }.must_raise AttrExtras::MethodNotImplementedError
     exception.message.must_equal "Implement a 'foo()' method"
   end
 
@@ -18,7 +18,7 @@ describe Object, ".attr_implement" do
 
     example = klass.new
 
-    exception = lambda { example.foo(1, 2) }.must_raise NotImplementedError
+    exception = lambda { example.foo(1, 2) }.must_raise AttrExtras::MethodNotImplementedError
     exception.message.must_equal "Implement a 'foo(name, age)' method"
 
     lambda { example.foo }.must_raise ArgumentError
@@ -64,21 +64,5 @@ describe Object, ".attr_implement" do
     end
 
     lambda { klass.new.some_other_method }.must_raise NoMethodError
-  end
-
-  it "raises an exception that is not caught by a generic runtime error rescue" do
-    klass = Class.new do
-      attr_implement :foo
-    end
-
-    example = klass.new
-    exception = lambda {
-      begin
-        example.foo
-      rescue
-        "Runtime error occured"
-      end
-    }.must_raise NotImplementedError
-    exception.message.must_equal "Implement a 'foo()' method"
   end
 end


### PR DESCRIPTION
I have another small improvement suggestion: if `attr_implement` raises `NotImplementedError` instead of `RuntimeError`, the error will pass through a `rescue` without a specific class (since that rescues `RuntimeError`).

This way a coding mistake will be found earlier if a class with `attr_implement` is used within a `rescue` block. Plus the name of the error is more descriptive.

`NotImplementedError` is a subclass of `ScriptError` instead of `StandardError` (see [this handy Ruby exception cheat sheet](http://cheat.errtheblog.com/s/exceptions))