### PR TITLE
Fix `rattr_initialize` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Example:
 
 ``` ruby
 class Item
-  pattr_initalize :name, :price
+  pattr_initialize :name, :price
 
   def price_with_vat
     price * 1.25
@@ -142,14 +142,14 @@ Example:
 
 ``` ruby
 class PublishBook
-  rattr_initalize :book_name, :publisher_backend
+  rattr_initialize :book_name, :publisher_backend
 
   def call
     publisher_backend.publish book_name
   end
 end
 
-service = PublishBook.new("A Novel")
+service = PublishBook.new("A Novel", publisher)
 service.book_name  # => "A Novel"
 ```
 


### PR DESCRIPTION
The example for `rattr_initialize` is creating an instance with a single argument, while calling `rattr_initialize` with two arguments. Running the code would cause an `ArgumentError` in `validate_arity`. This change adds the missing second argument to the instance initialization.

It also fixes typos in example calls to `rattr_initialize` and `pattr_initialize`.

Thanks for this great project!