### PR TITLE
Add `attr_accessor_initialize`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Also provides conveniences for creating value objects, method objects, query met
 * [`pattr_initialize`](#pattr_initialize) / [`attr_private_initialize`](#attr_private_initialize)
 * [`vattr_initialize`](#vattr_initialize) / [`attr_value_initialize`](#attr_value_initialize)
 * [`rattr_initialize`](#rattr_initialize) / [`attr_reader_initialize`](#attr_reader_initialize)
+* [`aattr_initialize`](#aattr_initialize) / [`attr_accessor_initialize`](#attr_accessor_initialize)
 * [`static_facade`](#static_facade)
 * [`method_object`](#method_object)
 * [`attr_implement`](#attr_implement)
@@ -154,6 +155,34 @@ service.book_name  # => "A Novel"
 ```
 
 [The `attr_initialize` notation](#attr_initialize) for hash arguments is also supported: `rattr_initialize :foo, [:bar, :baz!]`
+
+### `aattr_initialize`
+### `attr_accessor_initialize`
+
+`aattr_initialize :foo, :bar` defines an initializer, public readers, and public writers. It's a shortcut for:
+
+``` ruby
+attr_initialize :foo, :bar
+attr_accessor :foo, :bar
+```
+
+`aattr_initialize` is aliased as `attr_accessor_initialize`, if you prefer a longer but clearer name.
+
+Example:
+
+``` ruby
+class Client
+  aattr_initialize :username, :access_token
+end
+
+client = Client.new("barsoom", "SECRET")
+client.username # => "barsoom"
+
+client.access_token = "NEW_SECRET"
+client.access_token # => "NEW_SECRET"
+```
+
+[The `attr_initialize` notation](#attr_initialize) for hash arguments and blocks is also supported.
 
 ### `static_facade`
 

--- a/lib/attr_extras/explicit.rb
+++ b/lib/attr_extras/explicit.rb
@@ -54,6 +54,13 @@ module AttrExtras
 
     alias_method :attr_reader_initialize, :rattr_initialize
 
+    def aattr_initialize(*names, &block)
+      attr_initialize(*names, &block)
+      attr_accessor(*Utils.flat_names(names))
+    end
+
+    alias_method :attr_accessor_initialize, :aattr_initialize
+
     def static_facade(method_name, *names)
       define_singleton_method(method_name) do |*values|
         new(*values).public_send(method_name)

--- a/spec/attr_extras/aattr_initialize_spec.rb
+++ b/spec/attr_extras/aattr_initialize_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+
+describe Object, ".aattr_initialize" do
+  it "creates an initializer and public readers" do
+    klass = Class.new do
+      aattr_initialize :foo, :bar
+    end
+
+    example = klass.new("Foo", "Bar")
+
+    example.foo.must_equal "Foo"
+  end
+
+  it "creates public writers" do
+    klass = Class.new do
+      aattr_initialize :foo, :bar
+    end
+
+    example = klass.new("Foo", "Bar")
+    example.foo = "Baz"
+
+    example.foo.must_equal "Baz"
+  end
+
+  it "works with hash ivars" do
+    klass = Class.new do
+      aattr_initialize :foo, [:bar, :baz!]
+    end
+
+    example = klass.new("Foo", :bar => "Bar", :baz => "Baz")
+
+    example.baz.must_equal "Baz"
+  end
+
+  it "accepts a block for initialization" do
+    klass = Class.new do
+      aattr_initialize :value do
+        @copy = @value
+      end
+
+      attr_reader :copy
+    end
+
+    example = klass.new("expected")
+
+    example.copy.must_equal "expected"
+  end
+
+  it "accepts the alias attr_accessor_initialize" do
+    klass = Class.new do
+      attr_accessor_initialize :foo, :bar
+    end
+
+    example = klass.new("Foo", "Bar")
+
+    example.foo.must_equal "Foo"
+  end
+end

--- a/spec/attr_extras/pattr_initialize_spec.rb
+++ b/spec/attr_extras/pattr_initialize_spec.rb
@@ -33,7 +33,7 @@ describe Object, ".pattr_initialize" do
     example.copy.must_equal "expected"
   end
 
-  it "accepts the alias attr_private_initializer" do
+  it "accepts the alias attr_private_initialize" do
     klass = Class.new do
       attr_private_initialize :foo, :bar
     end

--- a/spec/attr_extras/rattr_initialize_spec.rb
+++ b/spec/attr_extras/rattr_initialize_spec.rb
@@ -19,7 +19,7 @@ describe Object, ".rattr_initialize" do
     example.public_send(:baz).must_equal "Baz"
   end
 
-  it "accepts the alias attr_reader_initializer" do
+  it "accepts the alias attr_reader_initialize" do
     klass = Class.new do
       attr_reader_initialize :foo, :bar
     end

--- a/spec/attr_extras/vattr_initialize_spec.rb
+++ b/spec/attr_extras/vattr_initialize_spec.rb
@@ -37,7 +37,7 @@ describe Object, ".vattr_initialize" do
     called.must_equal true
   end
 
-  it "accepts the alias attr_value_initializer" do
+  it "accepts the alias attr_value_initialize" do
     klass = Class.new do
       attr_value_initialize :foo, :bar
     end


### PR DESCRIPTION
This adds `aattr_initialize` / `attr_accessor_initialize` as requested in #18.

It defines an initializer, public readers, and public writers.

This PR also contains a commit to fix some typos in the specs.

Thanks for this great project!