### PR TITLE
Adding support for default values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ rvm:
   - 2.0.0
   - jruby-head
 before_install:  # For jruby-head to work.
-  - gem install bundler
+  - gem install bundler || gem install bundler --version '< 2'
   - gem update bundler

--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ Also provides conveniences for creating value objects, method objects, query met
 
 `attr_initialize [:bar, :baz!]` defines an initializer that takes two keyword arguments, assigning `@bar` (optional) and `@baz` (required).
 
+Keyword arguments can have default values:
+`attr_initialize [:bar, baz: "default value"]` defines an initializer that takes two keyword arguments, assigning `@bar` (optional) and `@baz` (optional with default value `"default value"`).
+
 If you pass unknown keyword arguments, you will get an `ArgumentError`.
+If you don't pass required arguments and don't define default value for them, you will get a `KeyError`.
 
 `attr_initialize` can also accept a block which will be invoked after initialization. This is useful for e.g. initializing private data as necessary.
 

--- a/Rakefile
+++ b/Rakefile
@@ -19,5 +19,5 @@ Rake::TestTask.new(:test_explicit) do |t|
   t.test_files = explicit_tests
 end
 
-task :test => [ :test_implicit, :test_explicit ]
-task :default => :test
+task test: [ :test_implicit, :test_explicit ]
+task default: :test

--- a/attr_extras.gemspec
+++ b/attr_extras.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = AttrExtras::VERSION
 
   gem.add_development_dependency "minitest", ">= 5"
-  gem.add_development_dependency "m", "~> 1.3.1"  # Running individual tests.
+  gem.add_development_dependency "m", "~> 1.5.0"  # Running individual tests.
 
   # For Travis CI.
   gem.add_development_dependency "rake"

--- a/lib/attr_extras/attr_initialize.rb
+++ b/lib/attr_extras/attr_initialize.rb
@@ -9,31 +9,29 @@ class AttrExtras::AttrInitialize
   def apply
     # The define_method block can't call our methods, so we need to make
     # things available via local variables.
-    names = @names
     block = @block
+    default_values_var = default_values
+    positional_args_var = positional_args
+
     validate_arity = method(:validate_arity)
-    set_ivar_from_hash = method(:set_ivar_from_hash)
+    validate_args = method(:validate_args)
 
     klass.send(:define_method, :initialize) do |*values|
+      hash_values = values.select { |name| name.is_a?(Hash) }.inject(:merge) || {}
+
       validate_arity.call(values.length, self.class)
+      validate_args.call(values, hash_values)
 
-      names.zip(values).each do |name_or_names, value|
-        if name_or_names.is_a?(Array)
-          hash = value || {}
+      default_values_var.each do |name, default_value|
+        instance_variable_set("@#{name}", default_value)
+      end
 
-          known_keys = name_or_names.map { |name| name.to_s.sub(/!\z/, "").to_sym }
-          unknown_keys = hash.keys - known_keys
-          if unknown_keys.any?
-            raise ArgumentError, "Got unknown keys: #{unknown_keys.inspect}; allowed keys: #{known_keys.inspect}"
-          end
+      positional_args_var.zip(values).each do |name, value|
+        instance_variable_set("@#{name}", value)
+      end
 
-          name_or_names.each do |name|
-            set_ivar_from_hash.call(self, name, hash)
-          end
-        else
-          name = name_or_names
-          instance_variable_set("@#{name}", value)
-        end
+      hash_values.each do |name, value|
+        instance_variable_set("@#{name}", value)
       end
 
       if block
@@ -43,6 +41,32 @@ class AttrExtras::AttrInitialize
   end
 
   private
+
+  def positional_args
+    @positional_args ||= names.take_while { |name| !name.is_a?(Array) }
+  end
+
+  def default_values
+    @default_values ||= begin
+      default_values_hash = names.flatten.select { |name| name.is_a?(Hash) }.inject(:merge) || {}
+      default_values_hash.transform_keys { |name| name.to_s.sub(/!\z/, "").to_sym }
+    end
+  end
+
+  def hash_args
+    @hash_args ||= (names - positional_args).flatten.map { |name|
+      name.is_a?(Hash) ? name.keys : name
+    }.flatten
+  end
+
+  def hash_args_names
+    @hash_args_names ||= hash_args.map { |name| name.to_s.sub(/!\z/, "").to_sym }
+  end
+
+  def hash_args_required
+    @hash_args_required ||= hash_args.select { |name| name.to_s.end_with?("!") }
+      .map { |name| name.to_s.chop.to_sym }
+  end
 
   def validate_arity(provided_arity, klass)
     arity_without_hashes = names.count { |name| not name.is_a?(Array) }
@@ -54,15 +78,16 @@ class AttrExtras::AttrInitialize
     end
   end
 
-  def set_ivar_from_hash(instance, name, hash)
-    if name.to_s.end_with?("!")
-      actual_name = name.to_s.chop.to_sym
-      value = hash.fetch(actual_name)
-    else
-      actual_name = name
-      value = hash[actual_name]
+  def validate_args(values, hash_values)
+    hash_values = values.select { |n| n.is_a?(Hash) }.inject(:merge) || {}
+    unknown_keys = hash_values.keys - hash_args_names
+    if unknown_keys.any?
+      raise ArgumentError, "Got unknown keys: #{unknown_keys.inspect}; allowed keys: #{hash_args_names.inspect}"
     end
 
-    instance.instance_variable_set("@#{actual_name}", value)
+    missing_args = hash_args_required - hash_values.keys - default_values.keys
+    if missing_args.any?
+      raise KeyError, "Missing required keys: #{missing_args.inspect}"
+    end
   end
 end

--- a/lib/attr_extras/params_builder.rb
+++ b/lib/attr_extras/params_builder.rb
@@ -1,0 +1,51 @@
+module AttrExtras
+  class AttrInitialize
+    class ParamsBuilder
+      REQUIRED_SIGN = "!".freeze
+
+      def initialize(names)
+        @names = names
+      end
+
+      attr_reader :names
+      private :names
+
+      def positional_args
+        @positional_args ||= names.take_while { |name| !name.is_a?(Array) }
+      end
+
+      def hash_args
+        @hash_args ||= (names - positional_args).flatten.map { |name|
+          name.is_a?(Hash) ? name.keys : name
+        }.flatten
+      end
+
+      def hash_args_names
+        @hash_args_names ||= hash_args.map { |name| remove_required_sign(name) }
+      end
+
+      def hash_args_required
+        @hash_args_required ||= hash_args.select { |name| name.to_s.end_with?(REQUIRED_SIGN) }
+          .map { |name| remove_required_sign(name) }
+      end
+
+      def default_values
+        @default_values ||= begin
+          default_values_hash = names.flatten.select { |name| name.is_a?(Hash) }.inject(:merge) || {}
+          cleared_default_values = {}
+          default_values_hash.each_key do |name|
+            cleared_name = remove_required_sign(name)
+            cleared_default_values[cleared_name] = default_values_hash[name]
+          end
+          cleared_default_values
+        end
+      end
+
+      private
+
+      def remove_required_sign(name)
+        name.to_s.sub(/#{REQUIRED_SIGN}\z/, "").to_sym
+      end
+    end
+  end
+end

--- a/spec/attr_extras/aattr_initialize_spec.rb
+++ b/spec/attr_extras/aattr_initialize_spec.rb
@@ -27,7 +27,7 @@ describe Object, ".aattr_initialize" do
       aattr_initialize :foo, [:bar, :baz!]
     end
 
-    example = klass.new("Foo", :bar => "Bar", :baz => "Baz")
+    example = klass.new("Foo", bar: "Bar", baz: "Baz")
 
     example.baz.must_equal "Baz"
   end

--- a/spec/attr_extras/attr_initialize_spec.rb
+++ b/spec/attr_extras/attr_initialize_spec.rb
@@ -33,6 +33,20 @@ describe Object, ".attr_initialize" do
     example.instance_variable_get("@baz").must_equal "Baz"
   end
 
+  it "can set default values for keyword arguments" do
+    klass = Class.new do
+      attr_initialize :foo, [:bar, baz: "default baz"]
+    end
+
+    example = klass.new("Foo", bar: "Bar")
+    example.instance_variable_get("@foo").must_equal "Foo"
+    example.instance_variable_get("@bar").must_equal "Bar"
+    example.instance_variable_get("@baz").must_equal "default baz"
+
+    example = klass.new("Foo", bar: "Bar", baz: "Baz")
+    example.instance_variable_get("@baz").must_equal "Baz"
+  end
+
   it "treats hash values as optional" do
     klass = Class.new do
       attr_initialize :foo, [:bar, :baz]

--- a/spec/attr_extras/attr_initialize_spec.rb
+++ b/spec/attr_extras/attr_initialize_spec.rb
@@ -39,10 +39,10 @@ describe Object, ".attr_initialize" do
     end
 
     example = klass.new("Foo", bar: "Bar")
-    example.instance_variable_get("@baz").must_equal nil
+    example.instance_variable_defined?("@baz").must_equal false
 
     example = klass.new("Foo")
-    example.instance_variable_get("@bar").must_equal nil
+    example.instance_variable_defined?("@bar").must_equal false
   end
 
   it "can require hash values" do

--- a/spec/attr_extras/attr_initialize_spec.rb
+++ b/spec/attr_extras/attr_initialize_spec.rb
@@ -27,7 +27,7 @@ describe Object, ".attr_initialize" do
       attr_initialize :foo, [:bar, :baz]
     end
 
-    example = klass.new("Foo", :bar => "Bar", :baz => "Baz")
+    example = klass.new("Foo", bar: "Bar", baz: "Baz")
     example.instance_variable_get("@foo").must_equal "Foo"
     example.instance_variable_get("@bar").must_equal "Bar"
     example.instance_variable_get("@baz").must_equal "Baz"
@@ -38,7 +38,7 @@ describe Object, ".attr_initialize" do
       attr_initialize :foo, [:bar, :baz]
     end
 
-    example = klass.new("Foo", :bar => "Bar")
+    example = klass.new("Foo", bar: "Bar")
     example.instance_variable_get("@baz").must_equal nil
 
     example = klass.new("Foo")
@@ -50,10 +50,10 @@ describe Object, ".attr_initialize" do
       attr_initialize [:optional, :required!]
     end
 
-    example = klass.new(:required => "X")
+    example = klass.new(required: "X")
     example.instance_variable_get("@required").must_equal "X"
 
-    lambda { klass.new(:optional => "X") }.must_raise KeyError
+    lambda { klass.new(optional: "X") }.must_raise KeyError
   end
 
   it "complains about unknown hash values" do
@@ -62,9 +62,9 @@ describe Object, ".attr_initialize" do
     end
 
     # Should not raise.
-    klass.new("Foo", :bar => "Bar", :baz => "Baz")
+    klass.new("Foo", bar: "Bar", baz: "Baz")
 
-    exception = lambda { klass.new("Foo", :bar => "Bar", :baz => "Baz", :hello => "Hello") }.must_raise ArgumentError
+    exception = lambda { klass.new("Foo", bar: "Bar", baz: "Baz", hello: "Hello") }.must_raise ArgumentError
     exception.message.must_include "[:hello]"
   end
 

--- a/spec/attr_extras/params_builder_spec.rb
+++ b/spec/attr_extras/params_builder_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+describe AttrExtras::AttrInitialize::ParamsBuilder do
+  subject { AttrExtras::AttrInitialize::ParamsBuilder.new(names) }
+
+  describe "when positional and hash params are present" do
+    let(:names) { [ :foo, :bar, [ :baz, :qux!, quux: "Quux" ]] }
+
+    it "properly devides params by the type" do
+      subject.positional_args.must_equal [ :foo, :bar ]
+      subject.hash_args.must_equal [ :baz, :qux!, :quux ]
+      subject.hash_args_names.must_equal [ :baz, :qux, :quux ]
+      subject.hash_args_required.must_equal [ :qux ]
+      subject.default_values.must_equal({ quux: "Quux" })
+    end
+  end
+
+  describe "when only positional params are present" do
+    let(:names) { [ :foo, :bar] }
+
+    it "properly devides params by the type" do
+      subject.positional_args.must_equal [ :foo, :bar ]
+      subject.hash_args.must_be_empty
+      subject.hash_args_names.must_be_empty
+      subject.hash_args_required.must_be_empty
+      subject.default_values.must_be_empty
+    end
+  end
+
+  describe "when only hash params are present" do
+    let(:names) { [[ { baz: "Baz" }, :qux!, { quux: "Quux" } ]] }
+
+    it "properly devides params by the type" do
+      subject.positional_args.must_be_empty
+      subject.hash_args.must_equal [ :baz, :qux!, :quux ]
+      subject.hash_args_names.must_equal [ :baz, :qux, :quux ]
+      subject.hash_args_required.must_equal [ :qux ]
+      subject.default_values.must_equal({ quux: "Quux", baz: "Baz" })
+    end
+  end
+
+  describe "when params are empty" do
+    let(:names) { [] }
+
+    it "properly devides params by the type" do
+      subject.positional_args.must_be_empty
+      subject.hash_args.must_be_empty
+      subject.hash_args_names.must_be_empty
+      subject.hash_args_required.must_be_empty
+      subject.default_values.must_be_empty
+    end
+  end
+end

--- a/spec/attr_extras/pattr_initialize_spec.rb
+++ b/spec/attr_extras/pattr_initialize_spec.rb
@@ -15,7 +15,7 @@ describe Object, ".pattr_initialize" do
       pattr_initialize :foo, [:bar, :baz!]
     end
 
-    example = klass.new("Foo", :bar => "Bar", :baz => "Baz")
+    example = klass.new("Foo", bar: "Bar", baz: "Baz")
     example.send(:baz).must_equal "Baz"
   end
 

--- a/spec/attr_extras/rattr_initialize_spec.rb
+++ b/spec/attr_extras/rattr_initialize_spec.rb
@@ -15,7 +15,7 @@ describe Object, ".rattr_initialize" do
       rattr_initialize :foo, [:bar, :baz!]
     end
 
-    example = klass.new("Foo", :bar => "Bar", :baz => "Baz")
+    example = klass.new("Foo", bar: "Bar", baz: "Baz")
     example.public_send(:baz).must_equal "Baz"
   end
 

--- a/spec/attr_extras/vattr_initialize_spec.rb
+++ b/spec/attr_extras/vattr_initialize_spec.rb
@@ -18,8 +18,8 @@ describe Object, ".vattr_initialize" do
       vattr_initialize :foo, [:bar, :baz!]
     end
 
-    example1 = klass.new("Foo", :bar => "Bar", :baz => "Baz")
-    example2 = klass.new("Foo", :bar => "Bar", :baz => "Baz")
+    example1 = klass.new("Foo", bar: "Bar", baz: "Baz")
+    example2 = klass.new("Foo", bar: "Bar", baz: "Baz")
     example1.baz.must_equal "Baz"
     example1.must_equal example2
   end


### PR DESCRIPTION
This PR adds support for default values for keyword arguments to `attr_initialize` as requested in #25.

The PR also contains changes to use new ruby syntax and to fix some warnings.