### PR TITLE
Fix ivars with default arguments for using with readers

### DIFF
--- a/lib/attr_extras/utils.rb
+++ b/lib/attr_extras/utils.rb
@@ -1,5 +1,6 @@
 module AttrExtras::Utils
   def self.flat_names(names)
-    names.flatten.map { |x| x.to_s.sub(/!\z/, "") }
+    names.flatten.map { |x| x.is_a?(Hash) ? x.keys : x }
+      .flatten.map { |x| x.to_s.sub(/!\z/, "") }
   end
 end

--- a/spec/attr_extras/aattr_initialize_spec.rb
+++ b/spec/attr_extras/aattr_initialize_spec.rb
@@ -32,6 +32,16 @@ describe Object, ".aattr_initialize" do
     example.baz.must_equal "Baz"
   end
 
+  it "works with hash ivars and default values" do
+    klass = Class.new do
+      aattr_initialize :foo, [bar: "Bar", baz!: 'Baz']
+    end
+
+    example = klass.new("Foo")
+
+    example.baz.must_equal "Baz"
+  end
+
   it "accepts a block for initialization" do
     klass = Class.new do
       aattr_initialize :value do

--- a/spec/attr_extras/pattr_initialize_spec.rb
+++ b/spec/attr_extras/pattr_initialize_spec.rb
@@ -19,6 +19,15 @@ describe Object, ".pattr_initialize" do
     example.send(:baz).must_equal "Baz"
   end
 
+  it "works with hash ivars and default values" do
+    klass = Class.new do
+      pattr_initialize :foo, [bar: "Bar", baz!: 'Baz']
+    end
+
+    example = klass.new("Foo")
+    example.send(:baz).must_equal "Baz"
+  end
+
   it "can reference private initializer methods in an initializer block" do
     klass = Class.new do
       pattr_initialize :value do

--- a/spec/attr_extras/rattr_initialize_spec.rb
+++ b/spec/attr_extras/rattr_initialize_spec.rb
@@ -19,6 +19,15 @@ describe Object, ".rattr_initialize" do
     example.public_send(:baz).must_equal "Baz"
   end
 
+  it "works with hash ivars and default values" do
+    klass = Class.new do
+      rattr_initialize :foo, [bar: "Bar", baz!: 'Baz']
+    end
+
+    example = klass.new("Foo")
+    example.send(:baz).must_equal "Baz"
+  end
+
   it "accepts the alias attr_reader_initialize" do
     klass = Class.new do
       attr_reader_initialize :foo, :bar

--- a/spec/attr_extras/utils_spec.rb
+++ b/spec/attr_extras/utils_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+describe AttrExtras::Utils do
+  describe "::flat_names" do
+    subject { AttrExtras::Utils.flat_names(names) }
+
+    describe "when pass list of arguments" do
+      let(:names) { [:foo, :bar] }
+
+      it { subject.must_equal ["foo", "bar"] }
+    end
+
+    describe 'whee pass hash ivars' do
+      let(:names) { [:foo, [:bar, :baz!]] }
+
+      it { subject.must_equal ["foo", "bar", "baz"] }
+    end
+
+    describe 'whee pass hash ivars with default values' do
+      let(:names) { [:foo, [bar: "Bar", baz!: "Bar"]] }
+
+      it { subject.must_equal ["foo", "bar", "baz"] }
+    end
+  end
+end
+

--- a/spec/attr_extras/vattr_initialize_spec.rb
+++ b/spec/attr_extras/vattr_initialize_spec.rb
@@ -24,6 +24,17 @@ describe Object, ".vattr_initialize" do
     example1.must_equal example2
   end
 
+  it "works with hash ivars and default values" do
+    klass = Class.new do
+      vattr_initialize :foo, [bar: "Bar", baz!: 'Baz']
+    end
+
+    example1 = klass.new("Foo")
+    example2 = klass.new("Foo")
+    example1.baz.must_equal "Baz"
+    example1.must_equal example2
+  end
+
   it "can accept an initializer block" do
     called = false
     klass = Class.new do


### PR DESCRIPTION
This PR fixes issue with using keyword arguments with default values in `pattr_initialize` (as well as `rattr_initialize` and other) method. (described this bug here https://github.com/barsoom/attr_extras/pull/28)

The main issue is that `Utils::flat_names` doesn't process correctly case when we pass hash in the names list with arguments. As a result, we get something like this

```ruby
> AttrExtras::Utils.flat_names(:foo, [bar: "Bar", baz!: "Bar"])
["foo", "{:bar=>\"Bar\", :baz!=>\"Bar\"}"]
```