### PR TITLE
Fix deprecations of global expectations for Minitest 6

### DIFF
--- a/spec/attr_extras/aattr_initialize_spec.rb
+++ b/spec/attr_extras/aattr_initialize_spec.rb
@@ -8,7 +8,7 @@ describe Object, ".aattr_initialize" do
 
     example = klass.new("Foo", "Bar")
 
-    example.foo.must_equal "Foo"
+    _(example.foo).must_equal "Foo"
   end
 
   it "creates public writers" do
@@ -19,7 +19,7 @@ describe Object, ".aattr_initialize" do
     example = klass.new("Foo", "Bar")
     example.foo = "Baz"
 
-    example.foo.must_equal "Baz"
+    _(example.foo).must_equal "Baz"
   end
 
   it "works with hash ivars" do
@@ -29,7 +29,7 @@ describe Object, ".aattr_initialize" do
 
     example = klass.new("Foo", bar: "Bar", baz: "Baz")
 
-    example.baz.must_equal "Baz"
+    _(example.baz).must_equal "Baz"
   end
 
   it "works with hash ivars and default values" do
@@ -39,7 +39,7 @@ describe Object, ".aattr_initialize" do
 
     example = klass.new("Foo")
 
-    example.baz.must_equal "Baz"
+    _(example.baz).must_equal "Baz"
   end
 
   it "accepts a block for initialization" do
@@ -53,7 +53,7 @@ describe Object, ".aattr_initialize" do
 
     example = klass.new("expected")
 
-    example.copy.must_equal "expected"
+    _(example.copy).must_equal "expected"
   end
 
   it "accepts the alias attr_accessor_initialize" do
@@ -63,6 +63,6 @@ describe Object, ".aattr_initialize" do
 
     example = klass.new("Foo", "Bar")
 
-    example.foo.must_equal "Foo"
+    _(example.foo).must_equal "Foo"
   end
 end

--- a/spec/attr_extras/attr_id_query_spec.rb
+++ b/spec/attr_extras/attr_id_query_spec.rb
@@ -15,6 +15,6 @@ describe Object, ".attr_id_query" do
   end
 
   it "requires a trailing questionmark" do
-    lambda { Object.attr_id_query(:foo) }.must_raise ArgumentError
+    _(lambda { Object.attr_id_query(:foo) }).must_raise ArgumentError
   end
 end

--- a/spec/attr_extras/attr_implement_spec.rb
+++ b/spec/attr_extras/attr_implement_spec.rb
@@ -7,8 +7,8 @@ describe Object, ".attr_implement" do
     end
 
     example = klass.new
-    exception = lambda { example.foo }.must_raise AttrExtras::MethodNotImplementedError
-    exception.message.must_equal "Implement a 'foo()' method"
+    exception = _(lambda { example.foo }).must_raise AttrExtras::MethodNotImplementedError
+    _(exception.message).must_equal "Implement a 'foo()' method"
   end
 
   it "allows specifying arity and argument names" do
@@ -18,10 +18,10 @@ describe Object, ".attr_implement" do
 
     example = klass.new
 
-    exception = lambda { example.foo(1, 2) }.must_raise AttrExtras::MethodNotImplementedError
-    exception.message.must_equal "Implement a 'foo(name, age)' method"
+    exception = _(lambda { example.foo(1, 2) }).must_raise AttrExtras::MethodNotImplementedError
+    _(exception.message).must_equal "Implement a 'foo(name, age)' method"
 
-    lambda { example.foo }.must_raise ArgumentError
+    _(lambda { example.foo }).must_raise ArgumentError
   end
 
   it "does not raise if method is implemented in a subclass" do
@@ -35,7 +35,7 @@ describe Object, ".attr_implement" do
       end
     end
 
-    subklass.new.foo.must_equal "bar"
+    _(subklass.new.foo).must_equal "bar"
   end
 
   # E.g. when Active Record defines column query methods like "admin?"
@@ -55,7 +55,7 @@ describe Object, ".attr_implement" do
       include foo_interface
     end
 
-    klass.new.foo.must_equal "bar"
+    _(klass.new.foo).must_equal "bar"
   end
 
   it "does not mess up missing-method handling" do
@@ -63,7 +63,7 @@ describe Object, ".attr_implement" do
       attr_implement :foo
     end
 
-    lambda { klass.new.some_other_method }.must_raise NoMethodError
+    _(lambda { klass.new.some_other_method }).must_raise NoMethodError
   end
 end
 
@@ -73,9 +73,9 @@ describe Object, ".cattr_implement" do
       cattr_implement :foo, [:name, :age]
     end
 
-    exception = lambda { klass.foo(1, 2) }.must_raise AttrExtras::MethodNotImplementedError
-    exception.message.must_equal "Implement a 'foo(name, age)' method"
+    exception = _(lambda { klass.foo(1, 2) }).must_raise AttrExtras::MethodNotImplementedError
+    _(exception.message).must_equal "Implement a 'foo(name, age)' method"
 
-    lambda { klass.foo }.must_raise ArgumentError
+    _(lambda { klass.foo }).must_raise ArgumentError
   end
 end

--- a/spec/attr_extras/attr_initialize_spec.rb
+++ b/spec/attr_extras/attr_initialize_spec.rb
@@ -13,13 +13,13 @@ describe Object, ".attr_initialize" do
 
   it "creates an initializer setting those instance variables" do
     example = klass.new("Foo", "Bar")
-    example.instance_variable_get("@foo").must_equal "Foo"
-    example.instance_variable_get("@bar").must_equal "Bar"
+    _(example.instance_variable_get("@foo")).must_equal "Foo"
+    _(example.instance_variable_get("@bar")).must_equal "Bar"
   end
 
   it "requires all arguments" do
-    exception = lambda { klass.new("Foo") }.must_raise ArgumentError
-    exception.message.must_equal "wrong number of arguments (1 for 2) for ExampleClass initializer"
+    exception = _(lambda { klass.new("Foo") }).must_raise ArgumentError
+    _(exception.message).must_equal "wrong number of arguments (1 for 2) for ExampleClass initializer"
   end
 
   it "can set ivars from a hash" do
@@ -28,9 +28,9 @@ describe Object, ".attr_initialize" do
     end
 
     example = klass.new("Foo", bar: "Bar", baz: "Baz")
-    example.instance_variable_get("@foo").must_equal "Foo"
-    example.instance_variable_get("@bar").must_equal "Bar"
-    example.instance_variable_get("@baz").must_equal "Baz"
+    _(example.instance_variable_get("@foo")).must_equal "Foo"
+    _(example.instance_variable_get("@bar")).must_equal "Bar"
+    _(example.instance_variable_get("@baz")).must_equal "Baz"
   end
 
   it "can set default values for keyword arguments" do
@@ -39,12 +39,12 @@ describe Object, ".attr_initialize" do
     end
 
     example = klass.new("Foo", bar: "Bar")
-    example.instance_variable_get("@foo").must_equal "Foo"
-    example.instance_variable_get("@bar").must_equal "Bar"
-    example.instance_variable_get("@baz").must_equal "default baz"
+    _(example.instance_variable_get("@foo")).must_equal "Foo"
+    _(example.instance_variable_get("@bar")).must_equal "Bar"
+    _(example.instance_variable_get("@baz")).must_equal "default baz"
 
     example = klass.new("Foo", bar: "Bar", baz: "Baz")
-    example.instance_variable_get("@baz").must_equal "Baz"
+    _(example.instance_variable_get("@baz")).must_equal "Baz"
   end
 
   it "treats hash values as optional" do
@@ -53,10 +53,10 @@ describe Object, ".attr_initialize" do
     end
 
     example = klass.new("Foo", bar: "Bar")
-    example.instance_variable_defined?("@baz").must_equal false
+    _(example.instance_variable_defined?("@baz")).must_equal false
 
     example = klass.new("Foo")
-    example.instance_variable_defined?("@bar").must_equal false
+    _(example.instance_variable_defined?("@bar")).must_equal false
   end
 
   it "can require hash values" do
@@ -65,9 +65,9 @@ describe Object, ".attr_initialize" do
     end
 
     example = klass.new(required: "X")
-    example.instance_variable_get("@required").must_equal "X"
+    _(example.instance_variable_get("@required")).must_equal "X"
 
-    lambda { klass.new(optional: "X") }.must_raise KeyError
+    _(lambda { klass.new(optional: "X") }).must_raise KeyError
   end
 
   it "complains about unknown hash values" do
@@ -78,8 +78,8 @@ describe Object, ".attr_initialize" do
     # Should not raise.
     klass.new("Foo", bar: "Bar", baz: "Baz")
 
-    exception = lambda { klass.new("Foo", bar: "Bar", baz: "Baz", hello: "Hello") }.must_raise ArgumentError
-    exception.message.must_include "[:hello]"
+    exception = _(lambda { klass.new("Foo", bar: "Bar", baz: "Baz", hello: "Hello") }).must_raise ArgumentError
+    _(exception.message).must_include "[:hello]"
   end
 
   # Regression.
@@ -99,8 +99,8 @@ describe Object, ".attr_initialize" do
     end
 
     # Provides a hash to "foo" but does not provide "bar".
-    exception = lambda { klass.new({ bar: 123 }) }.must_raise KeyError
-    exception.message.must_include "[:bar]"
+    exception = _(lambda { klass.new({ bar: 123 }) }).must_raise KeyError
+    _(exception.message).must_include "[:bar]"
   end
 
   # Regression.
@@ -113,7 +113,7 @@ describe Object, ".attr_initialize" do
     # Should not raise.
     example = klass.new({ "invalid.ivar.name" => 123 })
 
-    example.foo.must_equal({ "invalid.ivar.name" => 123 })
+    _(example.foo).must_equal({ "invalid.ivar.name" => 123 })
   end
 
   it "accepts a block for initialization" do
@@ -127,6 +127,6 @@ describe Object, ".attr_initialize" do
 
     example = klass.new("expected")
 
-    example.copy.must_equal "expected"
+    _(example.copy).must_equal "expected"
   end
 end

--- a/spec/attr_extras/attr_private_spec.rb
+++ b/spec/attr_extras/attr_private_spec.rb
@@ -11,8 +11,8 @@ describe Object, ".attr_private" do
     example = klass.new
     example.instance_variable_set("@foo", "Foo")
     example.instance_variable_set("@bar", "Bar")
-    example.send(:foo).must_equal "Foo"
-    example.send(:bar).must_equal "Bar"
-    lambda { example.foo }.must_raise NoMethodError
+    _(example.send(:foo)).must_equal "Foo"
+    _(example.send(:bar)).must_equal "Bar"
+    _(lambda { example.foo }).must_raise NoMethodError
   end
 end

--- a/spec/attr_extras/attr_query_spec.rb
+++ b/spec/attr_extras/attr_query_spec.rb
@@ -14,6 +14,6 @@ describe Object, ".attr_query" do
   end
 
   it "requires a trailing questionmark" do
-    lambda { Object.attr_query(:foo) }.must_raise ArgumentError
+    _(lambda { Object.attr_query(:foo) }).must_raise ArgumentError
   end
 end

--- a/spec/attr_extras/attr_value_spec.rb
+++ b/spec/attr_extras/attr_value_spec.rb
@@ -9,7 +9,7 @@ describe Object, ".attr_value" do
 
     example = klass.new
     example.instance_variable_set("@foo", "Foo")
-    example.foo.must_equal "Foo"
+    _(example.foo).must_equal "Foo"
   end
 
   it "does not create writers" do
@@ -17,7 +17,7 @@ describe Object, ".attr_value" do
       attr_value :foo
     end
 
-    lambda { klass.new.foo = "new value" }.must_raise NoMethodError
+    _(lambda { klass.new.foo = "new value" }).must_raise NoMethodError
   end
 
   describe "object equality" do
@@ -92,21 +92,21 @@ describe Object, ".attr_value" do
       klass1_bar = klass1.new("Bar")
       klass2_foo = klass2.new("Foo")
 
-      klass1_foo.hash.must_equal klass1_foo2.hash
-      klass1_foo.hash.wont_equal klass1_bar.hash
-      klass1_foo.hash.wont_equal klass2_foo.hash
+      _(klass1_foo.hash).must_equal klass1_foo2.hash
+      _(klass1_foo.hash).wont_equal klass1_bar.hash
+      _(klass1_foo.hash).wont_equal klass2_foo.hash
 
       assert klass1_foo.eql?(klass1_foo2), "Examples should be 'eql?'"
       refute klass1_foo.eql?(klass1_bar), "Examples should not be 'eql?'"
       refute klass1_foo.eql?(klass2_foo), "Examples should not be 'eql?'"
 
-      Set[klass1_foo, klass1_foo2, klass1_bar, klass2_foo].length.must_equal 3
+      _(Set[klass1_foo, klass1_foo2, klass1_bar, klass2_foo].length).must_equal 3
 
       hash = {}
       hash[klass1_foo] = :awyeah
       hash[klass1_bar] = :wat
       hash[klass2_foo] = :nooooo
-      hash[klass1_foo2].must_equal :awyeah
+      _(hash[klass1_foo2]).must_equal :awyeah
     end
   end
 end

--- a/spec/attr_extras/params_builder_spec.rb
+++ b/spec/attr_extras/params_builder_spec.rb
@@ -7,11 +7,11 @@ describe AttrExtras::AttrInitialize::ParamsBuilder do
     let(:names) { [ :foo, :bar, [ :baz, :qux!, quux: "Quux" ]] }
 
     it "properly devides params by the type" do
-      subject.positional_args.must_equal [ :foo, :bar ]
-      subject.hash_args.must_equal [ :baz, :qux!, :quux ]
-      subject.hash_args_names.must_equal [ :baz, :qux, :quux ]
-      subject.hash_args_required.must_equal [ :qux ]
-      subject.default_values.must_equal({ quux: "Quux" })
+      _(subject.positional_args).must_equal [ :foo, :bar ]
+      _(subject.hash_args).must_equal [ :baz, :qux!, :quux ]
+      _(subject.hash_args_names).must_equal [ :baz, :qux, :quux ]
+      _(subject.hash_args_required).must_equal [ :qux ]
+      _(subject.default_values).must_equal({ quux: "Quux" })
     end
   end
 
@@ -19,11 +19,11 @@ describe AttrExtras::AttrInitialize::ParamsBuilder do
     let(:names) { [ :foo, :bar] }
 
     it "properly devides params by the type" do
-      subject.positional_args.must_equal [ :foo, :bar ]
-      subject.hash_args.must_be_empty
-      subject.hash_args_names.must_be_empty
-      subject.hash_args_required.must_be_empty
-      subject.default_values.must_be_empty
+      _(subject.positional_args).must_equal [ :foo, :bar ]
+      _(subject.hash_args).must_be_empty
+      _(subject.hash_args_names).must_be_empty
+      _(subject.hash_args_required).must_be_empty
+      _(subject.default_values).must_be_empty
     end
   end
 
@@ -31,11 +31,11 @@ describe AttrExtras::AttrInitialize::ParamsBuilder do
     let(:names) { [[ { baz: "Baz" }, :qux!, { quux: "Quux" } ]] }
 
     it "properly devides params by the type" do
-      subject.positional_args.must_be_empty
-      subject.hash_args.must_equal [ :baz, :qux!, :quux ]
-      subject.hash_args_names.must_equal [ :baz, :qux, :quux ]
-      subject.hash_args_required.must_equal [ :qux ]
-      subject.default_values.must_equal({ quux: "Quux", baz: "Baz" })
+      _(subject.positional_args).must_be_empty
+      _(subject.hash_args).must_equal [ :baz, :qux!, :quux ]
+      _(subject.hash_args_names).must_equal [ :baz, :qux, :quux ]
+      _(subject.hash_args_required).must_equal [ :qux ]
+      _(subject.default_values).must_equal({ quux: "Quux", baz: "Baz" })
     end
   end
 
@@ -43,11 +43,11 @@ describe AttrExtras::AttrInitialize::ParamsBuilder do
     let(:names) { [] }
 
     it "properly devides params by the type" do
-      subject.positional_args.must_be_empty
-      subject.hash_args.must_be_empty
-      subject.hash_args_names.must_be_empty
-      subject.hash_args_required.must_be_empty
-      subject.default_values.must_be_empty
+      _(subject.positional_args).must_be_empty
+      _(subject.hash_args).must_be_empty
+      _(subject.hash_args_names).must_be_empty
+      _(subject.hash_args_required).must_be_empty
+      _(subject.default_values).must_be_empty
     end
   end
 end

--- a/spec/attr_extras/pattr_initialize_spec.rb
+++ b/spec/attr_extras/pattr_initialize_spec.rb
@@ -7,7 +7,7 @@ describe Object, ".pattr_initialize" do
     end
 
     example = klass.new("Foo", "Bar")
-    example.send(:foo).must_equal "Foo"
+    _(example.send(:foo)).must_equal "Foo"
   end
 
   it "works with hash ivars" do
@@ -16,7 +16,7 @@ describe Object, ".pattr_initialize" do
     end
 
     example = klass.new("Foo", bar: "Bar", baz: "Baz")
-    example.send(:baz).must_equal "Baz"
+    _(example.send(:baz)).must_equal "Baz"
   end
 
   it "works with hash ivars and default values" do
@@ -25,7 +25,7 @@ describe Object, ".pattr_initialize" do
     end
 
     example = klass.new("Foo")
-    example.send(:baz).must_equal "Baz"
+    _(example.send(:baz)).must_equal "Baz"
   end
 
   it "can reference private initializer methods in an initializer block" do
@@ -39,7 +39,7 @@ describe Object, ".pattr_initialize" do
 
     example = klass.new("expected")
 
-    example.copy.must_equal "expected"
+    _(example.copy).must_equal "expected"
   end
 
   it "accepts the alias attr_private_initialize" do
@@ -48,6 +48,6 @@ describe Object, ".pattr_initialize" do
     end
 
     example = klass.new("Foo", "Bar")
-    example.send(:foo).must_equal "Foo"
+    _(example.send(:foo)).must_equal "Foo"
   end
 end

--- a/spec/attr_extras/rattr_initialize_spec.rb
+++ b/spec/attr_extras/rattr_initialize_spec.rb
@@ -7,7 +7,7 @@ describe Object, ".rattr_initialize" do
     end
 
     example = klass.new("Foo", "Bar")
-    example.public_send(:foo).must_equal "Foo"
+    _(example.public_send(:foo)).must_equal "Foo"
   end
 
   it "works with hash ivars" do
@@ -16,7 +16,7 @@ describe Object, ".rattr_initialize" do
     end
 
     example = klass.new("Foo", bar: "Bar", baz: "Baz")
-    example.public_send(:baz).must_equal "Baz"
+    _(example.public_send(:baz)).must_equal "Baz"
   end
 
   it "works with hash ivars and default values" do
@@ -25,7 +25,7 @@ describe Object, ".rattr_initialize" do
     end
 
     example = klass.new("Foo")
-    example.send(:baz).must_equal "Baz"
+    _(example.send(:baz)).must_equal "Baz"
   end
 
   it "accepts the alias attr_reader_initialize" do
@@ -34,6 +34,6 @@ describe Object, ".rattr_initialize" do
     end
 
     example = klass.new("Foo", "Bar")
-    example.public_send(:foo).must_equal "Foo"
+    _(example.public_send(:foo)).must_equal "Foo"
   end
 end

--- a/spec/attr_extras/utils_spec.rb
+++ b/spec/attr_extras/utils_spec.rb
@@ -5,15 +5,15 @@ describe AttrExtras::Utils do
     subject { AttrExtras::Utils.flat_names(names) }
 
     it "strips any bangs from a flat list of arguments" do
-      AttrExtras::Utils.flat_names([ :foo, :bar! ]).must_equal [ "foo", "bar" ]
+      _(AttrExtras::Utils.flat_names([ :foo, :bar! ])).must_equal [ "foo", "bar" ]
     end
 
     it "flattens hash arguments and strips any bangs" do
-      AttrExtras::Utils.flat_names([ :foo, [ :bar, :baz! ] ]).must_equal [ "foo", "bar", "baz" ]
+      _(AttrExtras::Utils.flat_names([ :foo, [ :bar, :baz! ] ])).must_equal [ "foo", "bar", "baz" ]
     end
 
     it "flattens hash arguments with defaults and strips any bangs" do
-      AttrExtras::Utils.flat_names([ :foo, [ bar: "Bar", baz!: "Baz"] ]).must_equal [ "foo", "bar", "baz" ]
+      _(AttrExtras::Utils.flat_names([ :foo, [ bar: "Bar", baz!: "Baz"] ])).must_equal [ "foo", "bar", "baz" ]
     end
   end
 end

--- a/spec/attr_extras/vattr_initialize_spec.rb
+++ b/spec/attr_extras/vattr_initialize_spec.rb
@@ -9,8 +9,8 @@ describe Object, ".vattr_initialize" do
     example1 = klass.new("Foo", "Bar")
     example2 = klass.new("Foo", "Bar")
 
-    example1.foo.must_equal "Foo"
-    example1.must_equal example2
+    _(example1.foo).must_equal "Foo"
+    _(example1).must_equal example2
   end
 
   it "works with hash ivars" do
@@ -20,8 +20,8 @@ describe Object, ".vattr_initialize" do
 
     example1 = klass.new("Foo", bar: "Bar", baz: "Baz")
     example2 = klass.new("Foo", bar: "Bar", baz: "Baz")
-    example1.baz.must_equal "Baz"
-    example1.must_equal example2
+    _(example1.baz).must_equal "Baz"
+    _(example1).must_equal example2
   end
 
   it "works with hash ivars and default values" do
@@ -31,8 +31,8 @@ describe Object, ".vattr_initialize" do
 
     example1 = klass.new("Foo")
     example2 = klass.new("Foo")
-    example1.baz.must_equal "Baz"
-    example1.must_equal example2
+    _(example1.baz).must_equal "Baz"
+    _(example1).must_equal example2
   end
 
   it "can accept an initializer block" do
@@ -45,7 +45,7 @@ describe Object, ".vattr_initialize" do
 
     klass.new("expected")
 
-    called.must_equal true
+    _(called).must_equal true
   end
 
   it "accepts the alias attr_value_initialize" do
@@ -56,7 +56,7 @@ describe Object, ".vattr_initialize" do
     example1 = klass.new("Foo", "Bar")
     example2 = klass.new("Foo", "Bar")
 
-    example1.foo.must_equal "Foo"
-    example1.must_equal example2
+    _(example1.foo).must_equal "Foo"
+    _(example1).must_equal example2
   end
 end

--- a/spec/attr_extras_spec.rb
+++ b/spec/attr_extras_spec.rb
@@ -10,6 +10,6 @@ describe AttrExtras do
       include mod
     end
 
-    klass.new("Hello").send(:name).must_equal "Hello"
+    _(klass.new("Hello").send(:name)).must_equal "Hello"
   end
 end


### PR DESCRIPTION
Howdy,

I was running the test for this project. Saw a lot of warnings from Minitest.

The deprecation was introduced by [this commit](https://github.com/seattlerb/minitest/commit/e6bc4485730403faff6966c1671cf5de72b2d233#diff-bc989f70c05f8b1e6cce6dcf7cd61b9c).

There are [3 syntax](https://github.com/seattlerb/minitest/blob/96ba1dac6141599cce47ec298e7e72dc7d49812d/lib/minitest/spec.rb#L311-L313) to choose from:

```ruby
_(1 + 1).must_equal 2
value(1 + 1).must_equal 2
expect(1 + 1).must_equal 2
```

I pick the shortest one, I could update based on your preference.

Thanks.