### PR TITLE
Fix calling without argument warnings

### DIFF
--- a/lib/attr_extras/explicit.rb
+++ b/lib/attr_extras/explicit.rb
@@ -21,12 +21,10 @@ module AttrExtras
     end
 
     def attr_private(*names)
-      # Need this to avoid "private attribute?" warnings when running
-      # the full test suite; not sure why exactly.
-      public
-
-      attr_reader(*names)
-      private(*names)
+      if names && !names.empty?
+        attr_reader(*names)
+        private(*names)
+      end
     end
 
     def attr_value(*names)


### PR DESCRIPTION
Hello, this Pull Request has 2 changes:

- Remove public since it does not generate "private attribute?" warnings and this also fixes for following warning

  ```
  warning: calling public without arguments inside a method may not
  have the intended effect
  ```

- Check if names are not empty to fix following warning:

  ```
  warning: calling private without arguments inside a method may not
  have the intended effect
  ```

These calling without arguments warnings introduced by https://github.com/ruby/ruby/commit/2993b24a1ecc5fa3cc9f140bfd80669c3a3b7b9c from [ruby bug tracker #13249](https://bugs.ruby-lang.org/issues/13249).

I‘m not a fan of adding this `if`, but \\\_(ツ)_/.

Open to better suggestion, thanks!