### PR TITLE
Pass kwargs explicitly in explicit static_facade

### DIFF
--- a/lib/attr_extras/explicit.rb
+++ b/lib/attr_extras/explicit.rb
@@ -61,9 +61,17 @@ module AttrExtras
     alias_method :attr_accessor_initialize, :aattr_initialize
 
     def static_facade(method_name_or_names, *names)
-      Array(method_name_or_names).each do |method_name|
-        define_singleton_method(method_name) do |*values, &block|
-          new(*values).public_send(method_name, &block)
+      if names.any? { |name| name.is_a?(Array) }
+        Array(method_name_or_names).each do |method_name|
+          define_singleton_method(method_name) do |*args, **opts, &block|
+            new(*args, **opts).public_send(method_name, &block)
+          end
+        end
+      else
+        Array(method_name_or_names).each do |method_name|
+          define_singleton_method(method_name) do |*args, &block|
+            new(*args).public_send(method_name, &block)
+          end
         end
       end
 

--- a/spec/attr_extras/explicit_spec.rb
+++ b/spec/attr_extras/explicit_spec.rb
@@ -20,4 +20,37 @@ describe AttrExtras, "explicit mode" do
     refute has_methods_before_mixin
     assert has_methods_after_mixin
   end
+
+  it "mixes in a version of static_facade which does not blow up when the class method is called with an empty hash" do
+    klass = Class.new do
+      extend AttrExtras.mixin
+
+      static_facade :foo, :value
+
+      def foo
+      end
+    end
+
+    refute_raises_anything { klass.foo({}) }
+  end
+
+  it "mixes in a version of static_facade which does not emit warnings when the initializer is overridden with more keyword arguments" do
+    superklass = Class.new do
+      extend AttrExtras.mixin
+
+      static_facade :something, [:foo!, :bar!]
+
+      def something
+      end
+    end
+
+    klass = Class.new(superklass) do
+      def initialize(extra:, **rest)
+        super(**rest)
+        @extra = extra
+      end
+    end
+
+    refute_warnings_emitted { klass.something(foo: 1, bar: 2, extra: 'yay') }
+  end
 end

--- a/spec/spec_helper_without_loading_attr_extras.rb
+++ b/spec/spec_helper_without_loading_attr_extras.rb
@@ -2,3 +2,20 @@ require "minitest/autorun"
 require "minitest/pride"
 
 $: << File.dirname(__FILE__) + "/../lib"
+
+Minitest::Test.class_eval do
+  def refute_warnings_emitted(&block)
+    _, stderr = capture_io(&block)
+
+    assert stderr.empty?, -> do
+      warnings = stderr.strip.split("\n").map { |line| "  #{line}" }.join("\n")
+      "Expected no warnings to be emitted, but these ones were:\n\n#{warnings}"
+    end
+  end
+
+  def refute_raises_anything
+    yield
+  rescue => error
+    flunk "Expected no error to be raised, but got #{error.class} (#{error.message})."
+  end
+end


### PR DESCRIPTION
Beginning with Ruby 2.7.0, Ruby is a bit more strict about argument
splatting and spreading. Specifically, there is even more of a
difference between keyword arguments and positional arguments than there
was before, and when Ruby 3 is released, `*args` will no longer capture
keyword arguments — you must use `**kwargs`. ([See this post.][1]) So
when we are causing `.static_facade` to delegate most of its arguments
to `.new`, we must use a double-splat, otherwise we will get a warning.

[1]: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Fixes #33