### PR TITLE
CI: Use latest Ruby patch versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
-  - 2.7.0
-  - 2.6.5
-  - 2.5.7
-  - 2.4.9
+  - 2.7.1
+  - 2.6.6
+  - 2.5.8
+  - 2.4.10
   - jruby-head
 before_install:  # For jruby-head to work.
   - gem install bundler


### PR DESCRIPTION
This PR keeps the CI versions matrix up to date.