### PR TITLE
CI: JRuby head now comes w/ Bundler 2.1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,3 @@ rvm:
   - 2.5.8
   - 2.4.10
   - jruby-head
-before_install:  # For jruby-head to work.
-  - gem install bundler
-  - gem update bundler


### PR DESCRIPTION
This PR changes the CI setup to **no longer install Bundler manually**.

We no longer need a workaround to have access to it in JRuby head. 🎉 

# Screenshot before

In this screenshot, we can see that the step prior to `before_install` displays a Bundler 2.1.4 version already accessible.

<img width="1433" alt="bild" src="https://user-images.githubusercontent.com/211/82781141-5abf8400-9e59-11ea-9176-be9366986b99.png">

# Screenshot after

Now, the next step is `install.bundler`

<img width="1439" alt="bild" src="https://user-images.githubusercontent.com/211/82784125-30bd9000-9e60-11ea-9cc1-1aa6f694eeeb.png">
