### PR TITLE
(chore) Update m gem to 1.5.1

### DIFF
--- a/attr_extras.gemspec
+++ b/attr_extras.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = AttrExtras::VERSION
 
   gem.add_development_dependency "minitest", ">= 5"
-  gem.add_development_dependency "m", "~> 1.5.0"  # Running individual tests.
+  gem.add_development_dependency "m", "~> 1.5.1"  # Running individual tests.
 
   # For Travis CI.
   gem.add_development_dependency "rake"


### PR DESCRIPTION
  - this supports [multiline line number specifications](https://github.com/qrush/m/pull/61) of tests

<img width="859" alt="bild" src="https://user-images.githubusercontent.com/211/82784405-c0fbd500-9e60-11ea-937d-cf5b107a8cd7.png">
