### PR TITLE
CI: Add Ruby 3.1 to matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ["3.0", "2.7", "2.6", "2.5", "jruby-head"]
+        ruby-version: [3.1, "3.0", 2.7, 2.6, 2.5, jruby-head]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR adds Ruby 3.1 to the build matrix.