### PR TITLE
Configure Dependabot for GitHub Actions versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"


### PR DESCRIPTION
This lets you discover new versions of GitHub Actions (not often updated) passively, as Dependabot will offer PRs about new versions.

The benefit is: you can set it and forget it.