### PR TITLE
Issue 45 default values shared

### DIFF
--- a/lib/attr_extras/attr_initialize.rb
+++ b/lib/attr_extras/attr_initialize.rb
@@ -1,3 +1,4 @@
+require 'byebug'
 require "attr_extras/params_builder"
 
 class AttrExtras::AttrInitialize
@@ -27,7 +28,7 @@ class AttrExtras::AttrInitialize
       validate_args.call(values, klass_params)
 
       klass_params.default_values.each do |name, default_value|
-        instance_variable_set("@#{name}", default_value)
+        instance_variable_set("@#{name}", default_value.dup)
       end
 
       klass_params.positional_args.zip(values).each do |name, value|

--- a/lib/attr_extras/attr_initialize.rb
+++ b/lib/attr_extras/attr_initialize.rb
@@ -1,4 +1,3 @@
-require 'byebug'
 require "attr_extras/params_builder"
 
 class AttrExtras::AttrInitialize

--- a/spec/attr_extras/aattr_initialize_spec.rb
+++ b/spec/attr_extras/aattr_initialize_spec.rb
@@ -65,4 +65,29 @@ describe Object, ".aattr_initialize" do
 
     _(example.foo).must_equal "Foo"
   end
+
+  it "does not use the same default values across class instances" do
+    klass = Class.new do
+      aattr_initialize [:name, items: []]
+    end
+
+    data = [
+      { name: "One", items: [1, 2, 3] },
+      { name: "Two", items: [4, 5, 6] },
+    ]
+
+    results = data.each_with_object([]) do |datum, results|
+      name, items = datum.values_at(:name, :items)
+      foo = klass.new(name: name)
+
+      items.each do |n|
+        foo.items << n
+      end
+
+      results << foo
+    end
+
+    _(results.first.items).must_equal [1, 2, 3]
+    _(results.last.items).must_equal [4, 5, 6]
+  end
 end

--- a/spec/attr_extras/aattr_initialize_spec.rb
+++ b/spec/attr_extras/aattr_initialize_spec.rb
@@ -66,7 +66,7 @@ describe Object, ".aattr_initialize" do
     _(example.foo).must_equal "Foo"
   end
 
-  it "does not use the same default values across class instances" do
+  it "does not use the same default value object across class instances" do
     klass = Class.new do
       aattr_initialize [:name, items: []]
     end


### PR DESCRIPTION
Using @frank-west-iii 's first code example, slightly modified, we can see that the default array value being passed is ultimately the same object used in all instances of the class:

```
class Foo
  arr = []
  puts arr.object_id
  aattr_initialize [:name, items: arr]
end

data = [
  { name: "One", items: [1, 2, 3] },
  { name: "Two", items: [4, 5, 6] },
]

results = data.each_with_object([]) do |datum, results|
  name, items = datum.values_at(:name, :items)
  foo = Foo.new(name: name)

  items.each do |n|
    foo.items << n
  end

  results << foo
end

results.each do |res|
  puts res.items.object_id
end

# => 860
# => 860
# => 860
```

To solve this I simply dupe the value on initialization so each instance gets its own unique object. 