### PR TITLE
Do not dup class and module name constants

### DIFF
--- a/lib/attr_extras/attr_initialize.rb
+++ b/lib/attr_extras/attr_initialize.rb
@@ -27,7 +27,15 @@ class AttrExtras::AttrInitialize
       validate_args.call(values, klass_params)
 
       klass_params.default_values.each do |name, default_value|
-        instance_variable_set("@#{name}", default_value.dup)
+        if (default_value.is_a?(Module) || default_value.is_a?(Class)) &&
+          !default_value.name.nil? &&
+          Module.const_defined?(
+            (default_value.to_s if default_value.respond_to?(:to_s)),
+          )
+          instance_variable_set("@#{name}", default_value)
+        else
+          instance_variable_set("@#{name}", default_value.dup)
+        end
       end
 
       klass_params.positional_args.zip(values).each do |name, value|

--- a/spec/attr_extras/attr_initialize_spec.rb
+++ b/spec/attr_extras/attr_initialize_spec.rb
@@ -47,6 +47,18 @@ describe Object, ".attr_initialize" do
     _(example.instance_variable_get("@baz")).must_equal "Baz"
   end
 
+  it "can set constants as default values for positional arguments" do
+    klass = Class.new do
+      attr_initialize [ foo: AttrExtras ]
+    end
+
+    example = klass.new
+    _(example.instance_variable_get("@foo")).must_equal AttrExtras
+
+    example = klass.new(foo: AttrExtras::AttrInitialize)
+    _(example.instance_variable_get("@foo")).must_equal AttrExtras::AttrInitialize
+  end
+
   it "treats hash values as optional" do
     klass = Class.new do
       attr_initialize :foo, [ :bar, :baz ]


### PR DESCRIPTION
Say I want a service that calls another service. I can inject the class as a named argument.

```ruby
class MyServiceA
  method_object [:other_service]

  def call
    other_service.call
  end
end
```

But if I wanted to define a default service, I would end up with an anonymous class.

```ruby
class MyServiceB
  def self.call
    # do stuff
  end
end

class MyServiceA
  method_object [other_service: MyServiceB]

  def call
    other_service.call
  end
end
```
In many cases, it is not a big problem, but it does not make much sense to duplicate a class or a module either.

This PR is a possible solution.